### PR TITLE
Remove server and data_dir options from sysconfig

### DIFF
--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,1 +1,1 @@
-CMD_OPTS="agent -server -config-dir /etc/consul.d -data-dir /var/lib/consul"
+CMD_OPTS="agent -config-dir /etc/consul.d"


### PR DESCRIPTION
These options can be added via configuration under
/etc/consul.d, so they do not need to be in the sysconfig
file. The sysconfig file should contain only a minimum set of
options since they override options set under the conf dir, and
the conf dir is significantly easier to manage via configuration
management tools.