### PR TITLE
run service as an unpriviledged user

### DIFF
--- a/SOURCES/consul.init
+++ b/SOURCES/consul.init
@@ -24,7 +24,7 @@
 . /etc/rc.d/init.d/functions
 
 prog="consul"
-user="root"
+user="consul"
 exec="/usr/bin/$prog"
 pidfile="/var/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"

--- a/SOURCES/consul.service
+++ b/SOURCES/consul.service
@@ -3,6 +3,8 @@ Description=Consul is a tool for service discovery and configuration. Consul is 
 Documentation=http://www.consul.io
 
 [Service]
+User=consul
+Group=consul
 EnvironmentFile=-/etc/sysconfig/consul
 ExecStart=/usr/bin/consul $CMD_OPTS
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
there is no need to run consul as root user and hence we should run
it as unpriviledged user.
Also discussed here https://www.digitalocean.com/community/tutorials/how-to-configure-consul-in-a-production-environment-on-ubuntu-14-04