### PR TITLE
Remove the pidfile when we stop consul service

### DIFF
--- a/SOURCES/consul.init
+++ b/SOURCES/consul.init
@@ -69,6 +69,7 @@ stop() {
     RETVAL=$?
     echo
     [ $RETVAL -eq 0 ] && rm -f $lockfile
+    [ $RETVAL -eq 0 ] && rm -f $pidfile
     return $RETVAL
 }
 


### PR DESCRIPTION
I've encountered some strange behavior trying to restart consul. 
```
[root@localhost ~]# service consul restart
Shutting down consul:                                      [  OK  ]
Starting consul:
```
I've narrowed it down to not removing the pidfile on successful stop. When the pidfile is removed after stopping consul, this behavior is gone.
```
[root@localhost ~]# service consul restart
Shutting down consul:                                      [  OK  ]
Starting consul:                                           [  OK  ]
```