### PR TITLE
relatively minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Two RPMS: one each for the Consul binary and the WebUI.
   * Add `-bootstrap` **only** if this is the first server and instance.
 * Start the service and tail the logs `systemctl start consul.service` and `journalctl -f`.
   * To enable at reboot `systemctl enable consul.service`.
+* Consul may complain about the `GOMAXPROCS` setting. This is safe to ignore;
+  however, the warning can be supressed by uncommenting the appropriate line in
+  `/etc/sysconfig/consul`.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,66 @@
-RPM Spec for Consul
-======================
+# RPM Spec for Consul
 
 Tries to follow the [packaging guidelines](https://fedoraproject.org/wiki/Packaging:Guidelines) from Fedora.
 
 * Binary: `/usr/bin/consul`
-* Config: `/etc/consul.d/`
+* Config: `/etc/consul/`
+* Shared state: `/var/lib/consul/`
 * Sysconfig: `/etc/sysconfig/consul`
+* WebUI: `/usr/share/consul/`
 
-To Build
----------
+# Build
 
-To build the RPM (non-root user):
+Build the RPM as a non-root user from your home directory:
 
-1. Check out this repo
-2. Install rpmdevtools and mock 
+* Check out this repo. Seriously - check it out. Nice.
+    ```
+    git clone <this_repo_url>
+    ```
 
+* Install `rpmdevtools` and `mock`.
     ```
     sudo yum install rpmdevtools mock
     ```
-3. Set up your rpmbuild directory tree
 
+* Set up your rpmbuild directory tree.
     ```
     rpmdev-setuptree
     ```
-4. Link the spec file and sources from the repository into your rpmbuild/SOURCES directory
 
+* Link the spec file and sources.
     ```
-    ln -s ${repo}/SPECS/consul.spec rpmbuild/SPECS/
-    ln -s ${repo}/SOURCES/* rpmbuild/SOURCES/
+    ln -s $HOME/consul-rpm/SPECS/consul.spec rpmbuild/SPECS/
+    find $HOME/consul-rpm/SOURCES -type f -exec ln -s {} rpmbuild/SOURCES/ \;
     ```
-5. Download remote source files
 
+* Download remote source files
     ```
     spectool -g -R rpmbuild/SPECS/consul.spec
     ```
-6. Build the RPM
 
+* Build the RPM
     ```
     rpmbuild -ba rpmbuild/SPECS/consul.spec
     ```
 
-7. (Optional) Build for another Fedora release
+## Result
 
-    ```
-    sudo mock -r fedora-19-x86_64 --resultdir rpmbuild/RPMS/x86_64/ rpmbuild/SRPMS/consul-0.2.0-1.fc20.src.rpm 
-    ```
+Two RPMS: one each for the Consul binary and the WebUI.
 
-To run
----------------
+# Run
 
-1. Install the rpm
-2. Put config files in `/etc/consul.d/`
-3. Change command line arguments to consul in `/etc/sysconfig/consul`. **Note:** You should remove `-bootstrap` if this isn't the first server.
-4. Start the service and tail the logs `systemctl start consul.service` and `journalctl -f`
-  * To enable at reboot `systemctl enable consul.service`
+* Install the RPM.
+* Put config files in `/etc/consul/`.
+* Change command line arguments to consul in `/etc/sysconfig/consul`.
+  * Add `-bootstrap` **only** if this is the first server and instance.
+* Start the service and tail the logs `systemctl start consul.service` and `journalctl -f`.
+  * To enable at reboot `systemctl enable consul.service`.
 
-More info
----------
+## Config
+
+Config files are loaded in lexicographical order from the `config-dir`. Some
+sample configs are provided.
+
+# More info
+
 See the [consul.io](http://www.consul.io) website.

--- a/SOURCES/consul-ui.json
+++ b/SOURCES/consul-ui.json
@@ -1,0 +1,3 @@
+{
+    "ui_dir": "/usr/share/consul-ui"
+}

--- a/SOURCES/consul.json
+++ b/SOURCES/consul.json
@@ -1,0 +1,5 @@
+{
+    "server": true,
+    "data_dir": "/var/lib/consul",
+    "log_level": "INFO"
+}

--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,2 +1,2 @@
-CMD_OPTS="agent -config-dir /etc/consul.d"
-GOMAXPROCS=1
+CMD_OPTS="agent -config-dir=/etc/consul -data-dir=/var/lib/consul"
+#GOMAXPROCS=4

--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,2 +1,2 @@
-CMD_OPTS="agent -config-dir /etc/consul.d -data-dir /var/lib/consul"
-GOMAXPROCS=4
+CMD_OPTS="agent -config-dir /etc/consul.d"
+GOMAXPROCS=1

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,16 +1,18 @@
 Name:           consul
 Version:        0.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.
 
 Group:          System Environment/Daemons
 License:        MPLv2.0
 URL:            http://www.consul.io
-Source0:        https://dl.bintray.com/mitchellh/consul/%{version}_linux_amd64.zip
+Source0:        https://dl.bintray.com/mitchellh/%{name}/%{version}_linux_amd64.zip
 Source1:        %{name}.sysconfig
 Source2:        %{name}.service
 Source3:        %{name}.init
-Source4:        https://dl.bintray.com/mitchellh/consul/%{version}_web_ui.zip
+Source4:        https://dl.bintray.com/mitchellh/%{name}/%{version}_web_ui.zip
+Source5:        %{name}.json
+Source6:        %{name}-ui.json
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
@@ -36,19 +38,19 @@ Consul provides several key features:
 Consul comes with support for a beautiful, functional web UI. The UI can be used for viewing all services and nodes, viewing all health checks and their current status, and for reading and setting key/value data. The UI automatically supports multi-datacenter.
 
 %prep
-%setup -q -c
+%setup -q -c -b 4
 
 %install
 mkdir -p %{buildroot}/%{_bindir}
 cp consul %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_sysconfdir}/%{name}.d
+mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
+cp %{SOURCE5} %{buildroot}/%{_sysconfdir}/%{name}/consul.json-dist
+cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}/consul-ui.json-dist
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
-unzip %{SOURCE4}
-mv dist %{buildroot}/%{_sharedstatedir}/%{name}-ui
-rm %{buildroot}/%{_sharedstatedir}/%{name}-ui/.gitkeep
-echo '{ "ui_dir": "/var/lib/consul-ui" }' > %{buildroot}/%{_sysconfdir}/%{name}.d/ui.json
+mkdir -p %{buildroot}/%{_prefix}/share/%{name}-ui
+cp -r dist/* %{buildroot}/%{_prefix}/share/%{name}-ui
 
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
 mkdir -p %{buildroot}/%{_unitdir}
@@ -91,7 +93,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%dir %attr(750, root, consul) %{_sysconfdir}/%{name}.d
+%dir %attr(750, root, consul) %{_sysconfdir}/%{name}
+%attr(640, root, consul) %{_sysconfdir}/%{name}/consul.json-dist
 %dir %attr(750, consul, consul) %{_sharedstatedir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
@@ -102,14 +105,17 @@ rm -rf %{buildroot}
 %attr(755, root, root) %{_bindir}/consul
 
 %files ui
-%attr(-, root, consul) %{_sharedstatedir}/%{name}-ui
-%config(noreplace) %attr(640, root, consul) %{_sysconfdir}/%{name}.d/ui.json
+%attr(-, root, consul) %{_prefix}/share/%{name}-ui
+%attr(640, root, consul) %{_sysconfdir}/%{name}/consul-ui.json-dist
+
 
 %doc
 
 
-
 %changelog
+* Mon Mar 9 2015 Dan <phrawzty@mozilla.com>
+- Reduce runtime assumptions
+
 * Fri Mar 6 2015 mh <mh@immerda.ch>
 - update to 0.5.0
 - fix SysV init on restart

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -45,7 +45,7 @@ mkdir -p %{buildroot}/%{_bindir}
 cp consul %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
 cp %{SOURCE5} %{buildroot}/%{_sysconfdir}/%{name}/consul.json-dist
-cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}/consul-ui.json-dist
+cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}/
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
@@ -106,7 +106,7 @@ rm -rf %{buildroot}
 
 %files ui
 %attr(-, root, consul) %{_prefix}/share/%{name}-ui
-%attr(640, root, consul) %{_sysconfdir}/%{name}/consul-ui.json-dist
+%attr(640, root, consul) %{_sysconfdir}/%{name}/consul-ui.json
 
 
 %doc
@@ -114,7 +114,7 @@ rm -rf %{buildroot}
 
 %changelog
 * Mon Mar 9 2015 Dan <phrawzty@mozilla.com>
-- Reduce runtime assumptions
+- Internal maintenance (bump release)
 
 * Fri Mar 6 2015 mh <mh@immerda.ch>
 - update to 0.5.0

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -49,7 +49,7 @@ cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}/
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
-mkdir -p %{buildroot}/%{_prefix}/share/%{name}-ui
+mkdir -p %{buildroot}/%{_datadir}/%{name}-ui
 cp -r dist/* %{buildroot}/%{_prefix}/share/%{name}-ui
 
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
@@ -105,7 +105,7 @@ rm -rf %{buildroot}
 %attr(755, root, root) %{_bindir}/consul
 
 %files ui
-%attr(-, root, consul) %{_prefix}/share/%{name}-ui
+%config(noreplace) %attr(-, root, consul) %{_prefix}/share/%{name}-ui
 %attr(640, root, consul) %{_sysconfdir}/%{name}/consul-ui.json
 
 


### PR DESCRIPTION
Hello all,

I humbly propose the following PR with some minor edits, notably concerning the following items:

**`README.md`**
* Uses more idiomatic Markdown.
* Adds / clarifies a few points.

**`SOURCES/consul.json` & `SOURCES/consul-ui.json`**
* Added some sample configs; these are packaged with the `-dist` suffix, which is more idiomatic for packaging purposes.

**`SOURCES/sysconfig/consul`**
* Removed some runtime assumptions. This configuration is as minimal as possible - it should be up to the user to decide how to manage their own configuration.

**`SPECS/consul.spec`**
* Moved the UI to `/usr/share/consul-ui/` as specified by the [Fedora packaging guidelines](https://fedoraproject.org/wiki/Packaging:Guidelines#Web_Applications).
* Added the sample config files.
* Leveraged `setup` to unpack the UI archive (instead of running `unzip` manually) as this is both more portable and more idiomatic.
* Bumped the release.

@duritong @tomhillable `r?`