### PR TITLE
Adding a working Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ BUILD/*
 RPMS/*
 SRPMS/*
 SOURCES/*.zip
-Vagrantfile

--- a/README.md
+++ b/README.md
@@ -10,7 +10,22 @@ Tries to follow the [packaging guidelines](https://fedoraproject.org/wiki/Packag
 
 # Build
 
-Build the RPM as a non-root user from your home directory:
+If you have Vagrant installed, you can just check this repo out and do:
+
+* Check out this repo.
+    ```
+    git clone https://github.com/tomhillable/consul-rpm
+    ```
+* Edit Vagrantfile to point to your favourite box (Bento CentOS7 in this example).
+    ```
+    config.vm.box = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box"
+    ```
+* Vagrant up!
+    ```
+    vagrant up
+    ```
+
+Or, do it manually by building the RPM as a non-root user from your home directory:
 
 * Check out this repo. Seriously - check it out. Nice.
     ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,36 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$rpmbuild_script = <<SCRIPT
+
+echo "Provisioning started, installing packages..."
+sudo yum -y install rpmdevtools mock
+
+echo "Setting up rpm dev tree..."
+rpmdev-setuptree
+
+echo "Linking files..."
+ln -s /vagrant/SPECS/consul.spec $HOME/rpmbuild/SPECS/
+find /vagrant/SOURCES -type f -exec ln -s {} $HOME/rpmbuild/SOURCES/ \\;
+
+echo "Downloading dependencies..."
+spectool -g -R rpmbuild/SPECS/consul.spec
+
+echo "Building rpm..."
+rpmbuild -ba rpmbuild/SPECS/consul.spec
+
+echo "Copying rpms back to shared folder..."
+mkdir /vagrant/RPMS
+find $HOME/rpmbuild -type d -name "RPMS" -exec cp -r {} /vagrant/ \\;
+find $HOME/rpmbuild -type d -name "SRPMS" -exec cp -r {} /vagrant/ \\;
+
+SCRIPT
+
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = ""
+
+  config.vm.provision "shell", inline: $rpmbuild_script, privileged: false
+
+end


### PR DESCRIPTION
I saw a Vagrantfile in .gitignore, but IMO having a working example will save a lot of time for anyone who needs to package this up quickly or make a quick fix, so I added a working Vagrantfile with a shell provisioner that packs everything up and copies it back to the shared folder.