### PR TITLE
restrict consul-ui version to the same version as consul

### DIFF
--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -23,7 +23,7 @@ Requires(pre): shadow-utils
 
 %package ui
 Summary: Consul Web UI
-Requires: consul
+Requires: consul = %{version}
 
 %description
 Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.


### PR DESCRIPTION
I think it makes sense to enforce this direct relationship regarding the version, otherwise people might end up with incompatible versions.