### PR TITLE
log to syslog by default - fixes #14 & #15

### DIFF
--- a/SOURCES/consul.json
+++ b/SOURCES/consul.json
@@ -1,5 +1,6 @@
 {
     "server": true,
     "data_dir": "/var/lib/consul",
-    "log_level": "INFO"
+    "log_level": "INFO",
+    "enable_syslog": true
 }

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,6 +1,6 @@
 Name:           consul
 Version:        0.5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.
 
 Group:          System Environment/Daemons
@@ -113,6 +113,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Sun Oct 18 2015 mh <mh@immerda.ch>
+- log to syslog by default - fixes #14 & #15
+
 * Tue May 19 2015 nathan r. hruby <nhruby@gmail.com>
 - Bump to v0.5.2
 


### PR DESCRIPTION
By default consul logs to STDOUT, which systemd sends to syslog
and on EL6 (hence SysV-init based) systems, we redirected these
logs to our own logfile. Which can then grow endless. To keep
things consistent we enable logging to syslog by default through
consul.