### PR TITLE
consul.spec: Make version outside controllable

### DIFF
--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,5 +1,11 @@
+%if 0%{?_version:1}
+%define         _verstr      %{_version}
+%else
+%define         _verstr      0.6.0
+%endif
+
 Name:           consul
-Version:        0.6.0
+Version:        %{_verstr}
 Release:        1%{?dist}
 Summary:        Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.
 


### PR DESCRIPTION
By using RPM macros as, or similar to, the provided, it becomes possible
to simply specify the 'hard-coded' version in the SPEC file itself, or,
if one so chooses, by e.g. 'rpmbuild --define "_version 0.6.3"'.

This removes a piece of state from the spec file which can be handy,
if one uses consul-rpm to build but wants to avoid patching the spec
file on every build, to build another version.