### PR TITLE
Fix invalid counter to prevent startup issues when using a different port

### DIFF
--- a/SOURCES/consul.init
+++ b/SOURCES/consul.init
@@ -70,7 +70,7 @@ start() {
            sleep 1
         fi
 
-        (( count++ ))
+        (( curwait++ ))
     done
 
     if [ $ready -eq 1 ]; then


### PR DESCRIPTION
We ran into issues with this init-script since we use a different port to run consul.
It indefinitely does a sleep 1 and never continues, this change fixes that. 

Change-Id: Icc3d9fa576ce3143d0e1b0bdb2ae251dc273b48f