### PR TITLE
Configs in etc consul.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tries to follow the [packaging guidelines](https://fedoraproject.org/wiki/Packaging:Guidelines) from Fedora.
 
 * Binary: `/usr/bin/consul`
-* Config: `/etc/consul/`
+* Config: `/etc/consul.d/`
 * Shared state: `/var/lib/consul/`
 * Sysconfig: `/etc/sysconfig/consul`
 * WebUI: `/usr/share/consul/`

--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,2 +1,2 @@
-CMD_OPTS="agent -config-dir=/etc/consul -data-dir=/var/lib/consul"
+CMD_OPTS="agent -config-dir=/etc/consul.d -data-dir=/var/lib/consul"
 #GOMAXPROCS=4

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,7 +1,7 @@
 %if 0%{?_version:1}
 %define         _verstr      %{_version}
 %else
-%define         _verstr      0.7.0
+%define         _verstr      0.7.1
 %endif
 
 Name:           consul

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ SCRIPT
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box"
+  config.vm.box = ""
 
   config.vm.provision "shell", inline: $rpmbuild_script, privileged: false
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ SCRIPT
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = ""
+  config.vm.box = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box"
 
   config.vm.provision "shell", inline: $rpmbuild_script, privileged: false
 


### PR DESCRIPTION
All the documentation references /etc/consul.d for configuration.  I've had to create a symlink in my chef cookbook from /etc/consul.d to /etc/consul for deploying utilizing this RPM.  I was hoping this change to the sysconfig file used by the init script would remove that cludge.

The merge and revert of merge were add and remove the bento URL from the Vagrant file.