### PR TITLE
Configs into consul.d and consul-template.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tries to follow the [packaging guidelines](https://fedoraproject.org/wiki/Packaging:Guidelines) from Fedora.
 
 * Binary: `/usr/bin/consul`
-* Config: `/etc/consul/`
+* Config: `/etc/consul.d/`
 * Shared state: `/var/lib/consul/`
 * Sysconfig: `/etc/sysconfig/consul`
 * WebUI: `/usr/share/consul/`
@@ -122,7 +122,7 @@ Three RPMs:
 # Run
 
 * Install the RPM.
-* Put config files in `/etc/consul/`.
+* Put config files in `/etc/consul.d/`.
 * Change command line arguments to consul in `/etc/sysconfig/consul`.
   * Add `-bootstrap` **only** if this is the first server and instance.
 * Start the service and tail the logs `systemctl start consul.service` and `journalctl -f`.

--- a/SOURCES/consul-template.sysconfig
+++ b/SOURCES/consul-template.sysconfig
@@ -1,2 +1,1 @@
-CMD_OPTS="-config=/etc/consul-template/consul-template.config"
-
+CMD_OPTS="-config=/etc/consul-template.d/consul-template.config -config=/etc/consul-template/consul-template.config"

--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,2 +1,2 @@
-CMD_OPTS="agent -config-dir=/etc/consul -data-dir=/var/lib/consul"
+CMD_OPTS="agent -config-dir=/etc/consul.d -config-dir=/etc/consul -data-dir=/var/lib/consul"
 #GOMAXPROCS=4

--- a/SPECS/consul-template.spec
+++ b/SPECS/consul-template.spec
@@ -38,8 +38,8 @@ consul-template watches a series of templates on the file system, writing new ch
 %install
 mkdir -p %{buildroot}/%{_bindir}
 cp consul-template %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
-cp %{SOURCE4} %{buildroot}/%{_sysconfdir}/%{name}/consul-template.json-dist
+mkdir -p %{buildroot}/%{_sysconfdir}/%{name}.d
+cp %{SOURCE4} %{buildroot}/%{_sysconfdir}/%{name}.d/consul-template.json-dist
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
@@ -87,8 +87,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%dir %attr(750, root, consul-template) %{_sysconfdir}/%{name}
-%attr(640, root, consul-template) %{_sysconfdir}/%{name}/consul-template.json-dist
+%dir %attr(750, root, consul-template) %{_sysconfdir}/%{name}.d
+%attr(640, root, consul-template) %{_sysconfdir}/%{name}.d/consul-template.json-dist
 %dir %attr(750, consul-template, consul-template) %{_sharedstatedir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -126,7 +126,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Fri Dev 23 2016 Michael Mraz <michaelmraz@gmail.com>
+* Fri Dec 23 2016 Michael Mraz <michaelmraz@gmail.com>
 - Change default configs directory to /etc/consul.d and /etc/consul-template.d
   while the old ones are still supported
 

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,7 +1,7 @@
 %if 0%{?_version:1}
 %define         _verstr      %{_version}
 %else
-%define         _verstr      0.7.0
+%define         _verstr      0.7.1
 %endif
 
 Name:           consul
@@ -53,9 +53,9 @@ Consul comes with support for a beautiful, functional web UI. The UI can be used
 %install
 mkdir -p %{buildroot}/%{_bindir}
 cp consul %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
-cp %{SOURCE5} %{buildroot}/%{_sysconfdir}/%{name}/consul.json-dist
-cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}/
+mkdir -p %{buildroot}/%{_sysconfdir}/%{name}.d
+cp %{SOURCE5} %{buildroot}/%{_sysconfdir}/%{name}.d/consul.json-dist
+cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}.d/
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
@@ -105,8 +105,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%dir %attr(750, root, consul) %{_sysconfdir}/%{name}
-%attr(640, root, consul) %{_sysconfdir}/%{name}/consul.json-dist
+%dir %attr(750, root, consul) %{_sysconfdir}/%{name}.d
+%attr(640, root, consul) %{_sysconfdir}/%{name}.d/consul.json-dist
 %dir %attr(750, consul, consul) %{_sharedstatedir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
@@ -119,13 +119,17 @@ rm -rf %{buildroot}
 
 %files ui
 %config(noreplace) %attr(-, root, consul) %{_prefix}/share/%{name}-ui
-%attr(640, root, consul) %{_sysconfdir}/%{name}/consul-ui.json
+%attr(640, root, consul) %{_sysconfdir}/%{name}.d/consul-ui.json
 
 
 %doc
 
 
 %changelog
+* Tue Nov 29 2016 Michael Mraz <michaelmraz@gmail.com>
+- Bump default version to 0.7.1
+- Change default configs directory to /etc/consul.d and /etc/consul-template.d
+
 * Wed Sep 21 2016 Rumba <no@email.ext>
 - Bump to 0.7.0
 


### PR DESCRIPTION
The consul.io documentation refers to /etc/consul.d and /etc/consul-template.d for configuration files. See https://www.consul.io/intro/getting-started/services.html as an example.  The public consul Chef cookbook and several other configuration management tools also utilize this path when setting up configurations.

This PR is to create the consul, consul-ui and consul-template RPMs to be consistent with this configuration path pattern.

Also bumped the default consul and consul-ui version to 0.7.1.