### PR TITLE
Consul fails to start if /etc/consul is not present

### DIFF
--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -53,6 +53,7 @@ Consul comes with support for a beautiful, functional web UI. The UI can be used
 %install
 mkdir -p %{buildroot}/%{_bindir}
 cp consul %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}/%{_sysconfdir}/%{name}.d
 cp %{SOURCE5} %{buildroot}/%{_sysconfdir}/%{name}.d/consul.json-dist
 cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}.d/
@@ -105,6 +106,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%dir %attr(750, root, consul) %{_sysconfdir}/%{name}
 %dir %attr(750, root, consul) %{_sysconfdir}/%{name}.d
 %attr(640, root, consul) %{_sysconfdir}/%{name}.d/consul.json-dist
 %dir %attr(750, consul, consul) %{_sharedstatedir}/%{name}


### PR DESCRIPTION
Hi there,

I built from master an rpm and installed it on a fresh machine.  However, consul fails to start with:

````
sudo cat /var/log/consul 
==> Error reading '/etc/consul': open /etc/consul: no such file or directory
```` 

This could be fixed by removing 

````
-config-dir=/etc/consul
````

from: SOURCES/consul.sysconfig

However, I read the conversation on https://github.com/tomhillable/consul-rpm/pull/45 which says this was kept for backwards compatibility.   The only thing I could think of was to add the creation of /etc/consul back into the spec for consul.  Not sure if this is how you wish to address consul not starting on fresh install.

Hope that explains the pull request.

cheers
/dom 