### PR TITLE
V0.8 and remove legacy config dirs

### DIFF
--- a/SOURCES/consul-template.sysconfig
+++ b/SOURCES/consul-template.sysconfig
@@ -1,1 +1,1 @@
-CMD_OPTS="-config=/etc/consul-template.d/consul-template.config -config=/etc/consul-template/consul-template.config"
+CMD_OPTS="-config=/etc/consul-template.d/consul-template.config"

--- a/SOURCES/consul.init
+++ b/SOURCES/consul.init
@@ -64,7 +64,7 @@ start() {
     local ready=0
 
     while checkpid ${pid} && [ $curwait -lt ${MAXWAIT} ] && [ $ready -ne 1 ]; do
-        if netstat -nptl | grep -q "^tcp.*:8400.*LISTEN \+${pid}\/${prog}"; then
+        if netstat -nptl | grep -q "^tcp.*:8500.*LISTEN \+${pid}\/${prog}"; then
             ready=1
         else
            sleep 1

--- a/SOURCES/consul.sysconfig
+++ b/SOURCES/consul.sysconfig
@@ -1,2 +1,2 @@
-CMD_OPTS="agent -config-dir=/etc/consul.d -config-dir=/etc/consul -data-dir=/var/lib/consul"
+CMD_OPTS="agent -config-dir=/etc/consul.d -data-dir=/var/lib/consul"
 #GOMAXPROCS=4

--- a/SPECS/consul-template.spec
+++ b/SPECS/consul-template.spec
@@ -105,6 +105,7 @@ rm -rf %{buildroot}
 %changelog
 * Wed Apr 05 2017 mh <mh@immerda.ch>
 - Bumped version to 0.18.2
+- remove legacy location /etc/consul-template/
 * Wed Sep 28 2016 Andy Bohne <andy@andrewbohne.com>
 - Bumped version to 0.16.0
 * Thu Jun 30 2016 Paul Lussier <pllsaph@gmail.com>

--- a/SPECS/consul-template.spec
+++ b/SPECS/consul-template.spec
@@ -1,7 +1,7 @@
 %if 0%{?_version:1}
 %define         _verstr      %{_version}
 %else
-%define         _verstr      0.16.0
+%define         _verstr      0.18.2
 %endif
 
 Name:           consul-template
@@ -103,6 +103,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Apr 05 2017 mh <mh@immerda.ch>
+- Bumped version to 0.18.2
 * Wed Sep 28 2016 Andy Bohne <andy@andrewbohne.com>
 - Bumped version to 0.16.0
 * Thu Jun 30 2016 Paul Lussier <pllsaph@gmail.com>

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,7 +1,7 @@
 %if 0%{?_version:1}
 %define         _verstr      %{_version}
 %else
-%define         _verstr      0.8.0
+%define         _verstr      0.8.1
 %endif
 
 Name:           consul
@@ -126,6 +126,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Apr 24 2017 mh <mh@immerda.ch>
+- Bump to 0.8.1
+- Fix init script to check for http port to be listening
+
 * Wed Apr 05 2017 mh <mh@immerda.ch>
 - Bump to 0.8.0
 - remove legacy location /etc/consul/

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -53,7 +53,6 @@ Consul comes with support for a beautiful, functional web UI. The UI can be used
 %install
 mkdir -p %{buildroot}/%{_bindir}
 cp consul %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}/%{_sysconfdir}/%{name}.d
 cp %{SOURCE5} %{buildroot}/%{_sysconfdir}/%{name}.d/consul.json-dist
 cp %{SOURCE6} %{buildroot}/%{_sysconfdir}/%{name}.d/
@@ -106,7 +105,6 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%dir %attr(750, root, consul) %{_sysconfdir}/%{name}
 %dir %attr(750, root, consul) %{_sysconfdir}/%{name}.d
 %attr(640, root, consul) %{_sysconfdir}/%{name}.d/consul.json-dist
 %dir %attr(750, consul, consul) %{_sharedstatedir}/%{name}
@@ -130,6 +128,7 @@ rm -rf %{buildroot}
 %changelog
 * Wed Apr 05 2017 mh <mh@immerda.ch>
 - Bump to 0.8.0
+- remove legacy location /etc/consul/
 
 * Tue Feb 21 2017 Rumba <ice4o@hotmail.com>
 - Bump to 0.7.5

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,7 +1,7 @@
 %if 0%{?_version:1}
 %define         _verstr      %{_version}
 %else
-%define         _verstr      0.7.5
+%define         _verstr      0.8.0
 %endif
 
 Name:           consul
@@ -128,6 +128,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Apr 05 2017 mh <mh@immerda.ch>
+- Bump to 0.8.0
+
 * Tue Feb 21 2017 Rumba <ice4o@hotmail.com>
 - Bump to 0.7.5
 


### PR DESCRIPTION
So this updates to 0.8.0 & 0.18.2 for consul-template AND it removes our legacy support for the old config location.

I don't expect this to get merged without discussion, BUT I'd like to see it as a starting point to resolve the last few discussions we had around this topic.

E.g. in #56 or especially #54 