### PR TITLE
bump consul to 1.0.6 and switch to hcl config file format

### DIFF
--- a/SOURCES/consul.hcl
+++ b/SOURCES/consul.hcl
@@ -1,0 +1,42 @@
+# Run agent in server mode
+server = true
+
+data_dir = "/var/lib/consul"
+log_level = "INFO"
+
+# BOOTSTRAPPING and/or SINGLE NODE CLUSTER
+# Requires server = true. A server configured with
+# bootstrap_expect = n waits until n servers are available to
+# bootstrap the cluster.
+# Setting to 1 is equivalent to boostrap = true, turning on bootstrap
+# mode. In bootstrap mode a server is allowed to elect itself as
+# cluster leader. Only a single node can be in this mode. Used for
+# bootstrappping a cluster, or to RUN A SINGLE NODE CLUSTER (not recommended)
+# bootstrap = true
+
+# Enable built-in web UI, by default on port 8500
+# ui = true
+
+# Address to which Consul binds client interfaces, by default allows
+# only loopback connections.
+# client_addr = "127.0.0.1"
+
+
+# Security configuration, check first
+# https://www.consul.io/docs/agent/encryption.html
+
+# Gossip uses simmetric encryption, to generate a key use
+# 'consul keygen'
+# encrypt = "vOUi/EEEmdirT2W7AmKY/w=="
+
+# RPC encryption requires a CA certificate and a certificate signed by
+# that CA. All servers *MUST* have a certificate valid for
+# server.<datacenter>.<domain>, for example CN = server.dc1.consul
+# This is so that a compromised client with a client cert can not be
+# used in server mode.
+# cert_file = "/etc/consul.d/certs/consul_server_cert.pem"
+# key_file = "/etc/consul.d/certs/consul_server_key.pem"
+# ca_file = "/etc/consul.d/certs/CAcert.pem"
+# verify_outgoing = true
+# verify_server_hostname = true
+# verify_incoming = true

--- a/SOURCES/consul.json
+++ b/SOURCES/consul.json
@@ -1,5 +1,0 @@
-{
-    "server": true,
-    "data_dir": "/var/lib/consul",
-    "log_level": "INFO"
-}

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -16,7 +16,7 @@ Source0:        https://releases.hashicorp.com/%{name}/%{version}/%{name}_%{vers
 Source1:        %{name}.sysconfig
 Source2:        %{name}.service
 Source3:        %{name}.init
-Source4:        %{name}.json
+Source4:        %{name}.hcl
 Source5:        %{name}.logrotate
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
@@ -45,7 +45,7 @@ Consul provides several key features:
 mkdir -p %{buildroot}/%{_bindir}
 cp consul %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_sysconfdir}/%{name}.d
-cp %{SOURCE4} %{buildroot}/%{_sysconfdir}/%{name}.d/consul.json-dist
+cp %{SOURCE4} %{buildroot}/%{_sysconfdir}/%{name}.d/consul.hcl-dist
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 mkdir -p %{buildroot}/%{_sharedstatedir}/%{name}
@@ -94,7 +94,7 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %dir %attr(750, root, consul) %{_sysconfdir}/%{name}.d
-%attr(640, root, consul) %{_sysconfdir}/%{name}.d/consul.json-dist
+%attr(640, root, consul) %{_sysconfdir}/%{name}.d/consul.hcl-dist
 %dir %attr(750, consul, consul) %{_sharedstatedir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
@@ -113,6 +113,7 @@ rm -rf %{buildroot}
 %changelog
 * Sat Mar 10 2018 fmiz fulminemizzega@yahoo.it
 - Bump version to 1.0.6
+- switch config file format to hcl
 
 * Fri Aug 18 2017 leeuwenrjj leeuwenrjj@gmail.com
 - Bump version to 0.9.2

--- a/SPECS/consul.spec
+++ b/SPECS/consul.spec
@@ -1,7 +1,7 @@
 %if 0%{?_version:1}
 %define         _verstr      %{_version}
 %else
-%define         _verstr      1.0.1
+%define         _verstr      1.0.6
 %endif
 
 Name:           consul
@@ -111,6 +111,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Sat Mar 10 2018 fmiz fulminemizzega@yahoo.it
+- Bump version to 1.0.6
+
 * Fri Aug 18 2017 leeuwenrjj leeuwenrjj@gmail.com
 - Bump version to 0.9.2
 - Fix issue with prep


### PR DESCRIPTION
Hello,
this PR updates consul to 1.0.6 and changes consul configuration file from json to hcl. The main reason I made this change is because hcl supports comments.
I pushed more changes to my master branch, if I submit another PR do you think you would merge those?