### PR TITLE
Add docker compose configs to automate package builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ If you have Vagrant installed:
 
 If you prefer building it with Docker:
 
-* Build the Docker image. Note that you must amend the `Dockerfile` header if you want a specific OS build (default is `centos7`).
+### Manually
+* Build the Docker image. Note that you must amend the `Dockerfile` header if you want a specific OS build (`centos6` and `centos7` are currently included).
     ```
-    docker build -t consul:build .
+    docker build -t consul:build ./docker/centos7/
     ```
 
 * Run the build.
@@ -111,6 +112,21 @@ If you prefer building it with Docker:
     ```
 
 * Retrieve the built RPMs from `$HOME/consul-rpms`.
+
+
+### Docker compose
+Alternatively, there is a docker compose file included with this repo that
+automates the process of building the Docker image and running commands.
+
+* Build with:
+    ```shell
+    docker-compose run <centos6|centos7>
+    ```
+
+* Retrieve build rpms from `./RPMS`.
+
+Currently, the docker-compose services can be either `centos6` or `centos7` for
+each respective OS version.
 
 # Result
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+
+version: '3'
+services:
+  centos6:
+    build:
+      context: .
+      dockerfile: ./docker/centos6/Dockerfile
+    volumes:
+      - ./RPMS:/RPMS
+
+  centos7:
+    build:
+      context: .
+      dockerfile: ./docker/centos7/Dockerfile
+    volumes:
+      - ./RPMS:/RPMS

--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:centos6
+MAINTAINER Sebastien Le Digabel "sledigabel@gmail.com"
+
+RUN yum update -y
+RUN yum install -y rpmdevtools mock
+
+RUN cd /root && rpmdev-setuptree
+ADD SOURCES/* /root/rpmbuild/SOURCES/
+ADD SPECS/* /root/rpmbuild/SPECS/
+RUN ln -s /root/rpmbuild/RPMS /RPMS
+
+VOLUME ["/RPMS"]
+
+CMD set -x && cd /root && spectool -g -R rpmbuild/SPECS/consul.spec && rpmbuild -ba rpmbuild/SPECS/consul.spec

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,4 +1,3 @@
-# default build is for CentOS7, change the base image to fit your build.
 FROM centos:centos7
 MAINTAINER Sebastien Le Digabel "sledigabel@gmail.com"
 


### PR DESCRIPTION
Removes the need to manually edit the Dockerfile for non-CentOS-7 OS and manually setting up volumes.  Could also be extended with additional Dockerfiles for other OS variants (e.g. Fedora).